### PR TITLE
fix(build): migrate kotlinOptions to compilerOptions DSL for KGP 2.3 compatibility

### DIFF
--- a/UnmanagedAdapter/build.gradle.kts
+++ b/UnmanagedAdapter/build.gradle.kts
@@ -74,8 +74,16 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
+    publishing {
+        if (productFlavors.any { it.name == "remote" }) {
+            singleVariant("remoteRelease") {}
+        }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 


### PR DESCRIPTION
When this adapter is consumed by a Kotlin Gradle Plugin 2.3+ build (such as the monorepo it is included in), the legacy `kotlinOptions { jvmTarget = "17" }` block fails to evaluate — KGP 2.3 raises that DSL from a deprecation warning to a compile-time error. Standalone builds on the pinned KGP 1.9.21 are unaffected today but would inherit the same error on any future bump.

Migrate to the project-level `kotlin { compilerOptions { jvmTarget.set( JVM_17) } }` block, which has been available since KGP 1.9.0 and produces identical bytecode. The existing `compileOptions { … VERSION_17 }` block inside `android {}` is unchanged.

Also add a guarded `publishing { singleVariant("remoteRelease") {} }` block to satisfy KGP 2.3's new publication-configuration check, which warns when a `MavenPublication` (the existing `register<MavenPublication> ("remoteRelease")` block) references a variant without a corresponding `singleVariant(...)` declaration. The
`if (productFlavors.any { it.name == "remote" })` guard ensures source-consuming forkers who strip the `remote` flavor are not broken at configuration time — the block is a no-op for them and only opts in when the variant actually exists.

No change to the published AAR contents, POM, AAR metadata, or consumer-facing toolchain requirements beyond the KGP 1.9.0 floor implied by the new DSL (the adapter's own pinned KGP is already 1.9.21, so this floor is already in effect for source consumers today).